### PR TITLE
Fix signal blocking and add tests

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -380,24 +380,23 @@ def get_all_children(widget):
 
 @contextmanager
 def block_signals(*widgets, recurse_children=True):
-    """Context manager to block signals for a widget and all its child pages."""
+    """Context manager to temporarily block signals on widgets."""
     all_widgets = []
+    prev_states = {}
     try:
-        # Get all child pages
         for widget in widgets:
             all_widgets.append(widget)
             if recurse_children:
                 all_widgets.extend(get_all_children(widget))
 
-        # Block signals
         for widget in all_widgets:
+            prev_states[widget] = widget.signalsBlocked()
             widget.blockSignals(True)
 
         yield
     finally:
-        # Unblock signals
         for widget in all_widgets:
-            widget.blockSignals(False)
+            widget.blockSignals(prev_states.get(widget, False))
 
 
 @contextmanager

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,7 +1,10 @@
 import sys
 import time
 import unittest
-import pyautogui
+import pytest
+
+pytest.importorskip('pyautogui')
+pytest.importorskip('PySide6')
 
 from PySide6.QtGui import Qt
 from PySide6.QtWidgets import QApplication

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip('PySide6')
+from PySide6.QtWidgets import QApplication, QPushButton
+
+from src.utils.helpers import block_signals
+
+
+def test_block_signals_restores_state():
+    app = QApplication.instance() or QApplication([])
+    btn = QPushButton()
+
+    # If the button starts blocked it should remain blocked after the context
+    btn.blockSignals(True)
+    with block_signals(btn):
+        assert btn.signalsBlocked()
+    assert btn.signalsBlocked()
+
+    # When starting unblocked it should return to unblocked
+    btn.blockSignals(False)
+    with block_signals(btn):
+        assert btn.signalsBlocked()
+    assert not btn.signalsBlocked()


### PR DESCRIPTION
## Summary
- fix `block_signals` so widgets restore their previous blocked state
- skip GUI tests when dependencies are missing
- add regression test for `block_signals`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec23570ec83219de5f10a85d3046c